### PR TITLE
Config tweaks

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,10 +1,19 @@
+url: https://perso.ens-lyon.fr/lise.vaudor/Rpackages/glitter/
+
+template:
+  bootstrap: 5
+
+authors:
+  Lise Vaudor:
+    href: https://perso.ens-lyon.fr/lise.vaudor/
+
 reference:
 - title: "Main functions"
   desc: "These are the core functions of the glitter package."
 - contents:
-  - spq_add()
-  - spq_init()
-  - send()
+  - spq_add
+  - spq_init
+  - send
 - title: "General handling of query"
   desc: "These functions must be used to build the query before it is sent to the SPARQL endpoint. They detail the query and might lighten it e.g. through e.g. spq_head() or spq_summarise(), which might prove useful or even necessary to agree with the server's limits. On the other hand, their dplyr counterparts (filter(), select(), arrange(), mutate(), summarise()) apply to the table obtained as the result of the query."
 - contents:
@@ -13,3 +22,34 @@ reference:
   desc: "These functions help translate R syntax into SPARQL language"
 - contents:
   - starts_with("is_")
+- title: "Debugging"
+- contents:
+  - build_sparql
+- title: internal
+  contents:
+  - as_values
+  - build_graph_classes
+  - build_part_body
+  - build_part_select
+  - clean_wikidata_table
+  - count_items
+  - decompose_triplet
+  - get_claim
+  - get_claims
+  - get_description
+  - get_info
+  - get_label
+  - get_one_claim
+  - get_thing
+  - get_triplets
+  - get_varformula
+  - interpret_svo
+  - keep_prefix
+  - send_sparql
+  - show_graph_classes
+  - subclasses_of
+  - superclasses_of
+  - transform_wikidata_coords
+  - usual_endpoints
+  - usual_prefixes
+  - wd_properties


### PR DESCRIPTION
- Add current URL of pkgdown website (although it might change if deployed via GitHub Pages).
- Add URL for maintainer.
- Fix the syntax of the reference index configuration.
- Add missing functions including those who should not appear. Related: #16 
- Switch to pkgdown BS5 templates.