### PR TITLE
Create scheduled-R-CMD-check.yaml

### DIFF
--- a/.github/workflows/scheduled-R-CMD-check.yaml
+++ b/.github/workflows/scheduled-R-CMD-check.yaml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '5 12 * * 1' # Mondays at 12:05
 
-name: R-CMD-check
+name: R-CMD-check-scheduled
 
 jobs:
   R-CMD-check:

--- a/.github/workflows/scheduled-R-CMD-check.yaml
+++ b/.github/workflows/scheduled-R-CMD-check.yaml
@@ -1,0 +1,49 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  schedule:
+    - cron: '5 12 * * 1' # Mondays at 12:05
+
+name: R-CMD-check
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: macOS-latest,   r: 'release'}
+          - {os: windows-latest, r: 'release'}
+          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,   r: 'release'}
+          - {os: ubuntu-latest,   r: 'oldrel-1'}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck
+          needs: check
+
+      - name: Delete fixtures
+        run: |
+          rm -rf tests/testthat/fixtures
+          
+      - uses: r-lib/actions/check-r-package@v2


### PR DESCRIPTION
Fix #43

I could have added logic for the step deleting fixtures, instead of duplicating the file, but this seemed easier.