### PR TITLE
feat: Keep same variable name when using spq_mutate, spq_summarise

### DIFF
--- a/R/spq_mutate.R
+++ b/R/spq_mutate.R
@@ -18,8 +18,9 @@ spq_mutate = function(.query, ..., .label = NA, .within_box = c(NA, NA), .within
   variable_names = names(variables)
 
   # when trying to overwrite a variable name ----
-  if (any(question_mark(variable_names) %in% .query[["vars"]][["name"]])) {
-
+  renaming_to_do = any(question_mark(variable_names) %in% .query[["vars"]][["name"]])
+  if (renaming_to_do) {
+    ## rename in existing query object ----
     to_rename = un_question_mark(
       intersect(question_mark(variable_names), .query[["vars"]][["name"]])
     )
@@ -28,6 +29,7 @@ spq_mutate = function(.query, ..., .label = NA, .within_box = c(NA, NA), .within
       \(.query, x) spq_rename_var(.query, old = x, new = sprintf("%s0", x)),
       .init = .query
     )
+    ## rename in current arguments ----
     rename_in_defs = function(x, variables) {
       gsub(question_mark_escape(x), question_mark(sprintf("%s0", x)), variables)
     }
@@ -37,6 +39,7 @@ spq_mutate = function(.query, ..., .label = NA, .within_box = c(NA, NA), .within
       .init = variables
     )
     variables = rlang::set_names(variables, variable_names)
+    ## unselect the overwritten variable ----
     .query <- spq_select(.query, !!!sprintf("-%s0", to_rename))
   }
 

--- a/R/spq_rename_var.R
+++ b/R/spq_rename_var.R
@@ -5,10 +5,16 @@ spq_rename_var <- function(.query, old, new) {
   }
 
   if (question_mark(new) %in% .query[["vars"]][["name"]]) {
-    cli::cli_abort("Can't rename {.field {old}} to {.field {new}} as {.field {new}} already exists.")
+    if (.query[["vars"]][["renamed"]][.query[["vars"]][["name"]] == question_mark(new)]) {
+      .query = spq_rename_var(.query, new, sprintf("%s0", new))
+    } else {
+      cli::cli_abort("Can't rename {.field {old}} to {.field {new}} as {.field {new}} already exists.")
+    }
+
   }
 
   .query[["vars"]] <- spq_rename_var_in_df(.query[["vars"]], old, new)
+  .query[["vars"]][["renamed"]][.query[["vars"]][["name"]] == question_mark(new)] <- TRUE
 
   .query[["structure"]] <- spq_rename_var_in_df(.query[["structure"]], old, new)
 

--- a/R/tracking.R
+++ b/R/tracking.R
@@ -49,7 +49,8 @@ track_vars <- function(.query,
     values = values,
     formula = formula,
     fun = fun,
-    ancestor = ancestor
+    ancestor = ancestor,
+    renamed = FALSE
   )
   .query[["vars"]] <- rbind(.query[["vars"]], new_var)
 

--- a/R/verbosity.R
+++ b/R/verbosity.R
@@ -1,0 +1,3 @@
+glitter_chatty <- function() {
+  !getOption("glitter.quiet", default = FALSE)
+}

--- a/README.Rmd
+++ b/README.Rmd
@@ -51,6 +51,20 @@ To perform the query,
 spq_perform(query)
 ```
 
+To get a random subset of movies with the date they were released, you could use
+
+```{r}
+spq_init() %>%
+  spq_add("?film wdt:P31 wd:Q11424") %>%
+  spq_label(film) %>%
+  spq_add("?film wdt:P577 ?date") %>%
+  spq_mutate(date = year(date)) %>%
+  spq_head(10) %>%
+  spq_perform()
+```
+
+Note that we were able to "overwrite" the date variable, which is straightforward in dplyr, but not so much in SPARQL.
+
 ## Installation
 
 Install this packages through R-universe:

--- a/README.md
+++ b/README.md
@@ -71,6 +71,35 @@ spq_perform(query)
 #> 5 http://www.wikidata.org/entity/Q24074986 From Freebase to Wikidata: The Great…
 ```
 
+To get a random subset of movies with the date they were released, you
+could use
+
+``` r
+spq_init() %>%
+  spq_add("?film wdt:P31 wd:Q11424") %>%
+  spq_label(film) %>%
+  spq_add("?film wdt:P577 ?date") %>%
+  spq_mutate(date = year(date)) %>%
+  spq_head(10) %>%
+  spq_perform()
+#> # A tibble: 10 × 3
+#>    film                                  date film_label       
+#>    <chr>                                <dbl> <chr>            
+#>  1 http://www.wikidata.org/entity/Q372   2009 We Live in Public
+#>  2 http://www.wikidata.org/entity/Q595   2011 The Intouchables 
+#>  3 http://www.wikidata.org/entity/Q595   2011 The Intouchables 
+#>  4 http://www.wikidata.org/entity/Q595   2012 The Intouchables 
+#>  5 http://www.wikidata.org/entity/Q595   2012 The Intouchables 
+#>  6 http://www.wikidata.org/entity/Q593   2011 A Gang Story     
+#>  7 http://www.wikidata.org/entity/Q1365  1974 Swept Away       
+#>  8 http://www.wikidata.org/entity/Q1365  1974 Swept Away       
+#>  9 http://www.wikidata.org/entity/Q1365  1975 Swept Away       
+#> 10 http://www.wikidata.org/entity/Q1365  1975 Swept Away
+```
+
+Note that we were able to “overwrite” the date variable, which is
+straightforward in dplyr, but not so much in SPARQL.
+
 ## Installation
 
 Install this packages through R-universe:

--- a/tests/testthat/_snaps/spq_mutate.md
+++ b/tests/testthat/_snaps/spq_mutate.md
@@ -16,11 +16,9 @@
 # spq_mutate with renaming
 
     Code
-      spq_init() %>% spq_add("?film wdt:P31 wd:Q11424", .label = "film") %>% spq_add(
-        "?film wdt:P577 ?date") %>% spq_mutate(date = year(date)) %>% spq_head(10)
-    Warning <lifecycle_warning_deprecated>
-      The `.label` argument of `spq_add()` is deprecated as of glitter 0.2.0.
-      i Ability to use `.label` will be dropped in next release, use `spq_label()` instead.
+      spq_init() %>% spq_add("?film wdt:P31 wd:Q11424") %>% spq_label(film) %>%
+        spq_add("?film wdt:P577 ?date") %>% spq_mutate(date = year(date)) %>%
+        spq_head(10)
     Output
       PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
       SELECT ?film (YEAR(?date0) AS ?date) (COALESCE(?film_labell,'') AS ?film_label)

--- a/tests/testthat/_snaps/spq_mutate.md
+++ b/tests/testthat/_snaps/spq_mutate.md
@@ -36,3 +36,25 @@
       
       LIMIT 10
 
+# spq_mutate with double renaming
+
+    Code
+      spq_init() %>% spq_add("?film wdt:P31 wd:Q11424") %>% spq_label(film) %>%
+        spq_add("?film wdt:P577 ?date") %>% spq_mutate(date = year(date)) %>%
+        spq_mutate(date = date - 2000)
+    Output
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      SELECT ?film (?date0-2000 AS ?date) (COALESCE(?film_labell,'') AS ?film_label)
+      WHERE {
+      
+      ?film wdt:P31 wd:Q11424.
+      OPTIONAL {
+      	?film rdfs:label ?film_labell.
+      	FILTER(lang(?film_labell) IN ('en'))
+      }
+      
+      ?film wdt:P577 ?date00.
+      BIND(YEAR(?date00) AS ?date0)
+      }
+      
+

--- a/tests/testthat/_snaps/spq_mutate.md
+++ b/tests/testthat/_snaps/spq_mutate.md
@@ -13,3 +13,28 @@
       }
       
 
+# spq_mutate with renaming
+
+    Code
+      spq_init() %>% spq_add("?film wdt:P31 wd:Q11424", .label = "film") %>% spq_add(
+        "?film wdt:P577 ?date") %>% spq_mutate(date = year(date)) %>% spq_head(10)
+    Warning <lifecycle_warning_deprecated>
+      The `.label` argument of `spq_add()` is deprecated as of glitter 0.2.0.
+      i Ability to use `.label` will be dropped in next release, use `spq_label()` instead.
+    Output
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      SELECT ?film (YEAR(?date0) AS ?date) (COALESCE(?film_labell,'') AS ?film_label)
+      WHERE {
+      
+      ?film wdt:P31 wd:Q11424.
+      OPTIONAL {
+      	?film rdfs:label ?film_labell.
+      	FILTER(lang(?film_labell) IN ('en'))
+      }
+      
+      ?film wdt:P577 ?date0.
+      
+      }
+      
+      LIMIT 10
+

--- a/tests/testthat/_snaps/spq_summarise.md
+++ b/tests/testthat/_snaps/spq_summarise.md
@@ -114,3 +114,69 @@
       }
       
 
+# spq_summarize() works with renaming
+
+    Code
+      spq_init() %>% spq_add("?item wdt:P361 wd:Q297853") %>% spq_add(
+        "?item wdt:P1082 ?folkm_ngd") %>% spq_add("?area wdt:P31 wd:Q1907114") %>%
+        spq_label(area) %>% spq_add("?area wdt:P527 ?item") %>% spq_group_by(area,
+        area_label) %>% spq_summarise(folkm_ngd = sum(folkm_ngd))
+    Output
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      SELECT ?area ?area_label (SUM(?folkm_ngd0) AS ?folkm_ngd)
+      WHERE {
+      
+      ?item wdt:P361 wd:Q297853.
+      ?item wdt:P1082 ?folkm_ngd0.
+      ?area wdt:P31 wd:Q1907114.
+      OPTIONAL {
+      	?area rdfs:label ?area_labell.
+      	FILTER(lang(?area_labell) IN ('en'))
+      }
+      
+      ?area wdt:P527 ?item.
+      BIND(COALESCE(?area_labell,'') AS ?area_label)
+      }
+      GROUP BY ?area ?area_label
+      
+
+---
+
+    Code
+      spq_init() %>% spq_add("?film wdt:P31 wd:Q11424") %>% spq_add(
+        "?film wdt:P840 ?loc") %>% spq_add("?film wdt:P577 ?date") %>% spq_mutate(
+        year = year(date)) %>% spq_mutate(yearmin = min(year)) %>% spq_group_by(loc,
+        yearmin) %>% spq_summarize(n_films = n())
+    Output
+      
+      SELECT ?loc ?yearmin (COUNT(*) AS ?n_films)
+      WHERE {
+      
+      ?film wdt:P31 wd:Q11424.
+      ?film wdt:P840 ?loc.
+      ?film wdt:P577 ?date.
+      BIND(YEAR(?date) AS ?year)
+      BIND(MIN(?year) AS ?yearmin)
+      }
+      GROUP BY ?loc ?yearmin
+      
+
+---
+
+    Code
+      spq_init() %>% spq_add("?film wdt:P31 wd:Q11424") %>% spq_head(10) %>% spq_add(
+        "?film wdt:P577 ?date") %>% spq_mutate(year = year(date)) %>% spq_group_by(
+        filmLabel, loc) %>% spq_summarise(year = min(year))
+    Output
+      
+      SELECT (MIN(?year0) AS ?year)
+      WHERE {
+      
+      ?film wdt:P31 wd:Q11424.
+      ?film wdt:P577 ?date.
+      BIND(YEAR(?date) AS ?year0)
+      }
+      GROUP BY ?filmLabel ?loc
+      
+      LIMIT 10
+

--- a/tests/testthat/_snaps/spq_summarise.md
+++ b/tests/testthat/_snaps/spq_summarise.md
@@ -145,20 +145,20 @@
     Code
       spq_init() %>% spq_add("?film wdt:P31 wd:Q11424") %>% spq_add(
         "?film wdt:P840 ?loc") %>% spq_add("?film wdt:P577 ?date") %>% spq_mutate(
-        year = year(date)) %>% spq_mutate(yearmin = min(year)) %>% spq_group_by(loc,
-        yearmin) %>% spq_summarize(n_films = n())
+        year = year(date)) %>% spq_mutate(year = min(year)) %>% spq_group_by(loc,
+        year) %>% spq_summarize(n_films = n())
     Output
       
-      SELECT ?loc ?yearmin (COUNT(*) AS ?n_films)
+      SELECT ?loc ?year (COUNT(*) AS ?n_films)
       WHERE {
       
       ?film wdt:P31 wd:Q11424.
       ?film wdt:P840 ?loc.
       ?film wdt:P577 ?date.
-      BIND(YEAR(?date) AS ?year)
-      BIND(MIN(?year) AS ?yearmin)
+      BIND(YEAR(?date) AS ?year0)
+      BIND(MIN(?year0) AS ?year)
       }
-      GROUP BY ?loc ?yearmin
+      GROUP BY ?loc ?year
       
 
 ---

--- a/tests/testthat/test-spq_mutate.R
+++ b/tests/testthat/test-spq_mutate.R
@@ -9,7 +9,8 @@ test_that("spq_mutate works", {
 test_that("spq_mutate with renaming", {
   expect_snapshot(
     spq_init() %>%
-      spq_add("?film wdt:P31 wd:Q11424",.label="film") %>%
+      spq_add("?film wdt:P31 wd:Q11424") %>%
+      spq_label(film) %>%
       spq_add("?film wdt:P577 ?date") %>%
       spq_mutate(date=year(date)) %>%
       spq_head(10)

--- a/tests/testthat/test-spq_mutate.R
+++ b/tests/testthat/test-spq_mutate.R
@@ -5,3 +5,14 @@ test_that("spq_mutate works", {
       spq_mutate(lang = lang(statement))
   )
 })
+
+test_that("spq_mutate with renaming", {
+  expect_snapshot(
+    spq_init() %>%
+      spq_add("?film wdt:P31 wd:Q11424",.label="film") %>%
+      spq_add("?film wdt:P577 ?date") %>%
+      spq_mutate(date=year(date)) %>%
+      spq_head(10)
+  )
+})
+

--- a/tests/testthat/test-spq_mutate.R
+++ b/tests/testthat/test-spq_mutate.R
@@ -17,3 +17,14 @@ test_that("spq_mutate with renaming", {
   )
 })
 
+test_that("spq_mutate with double renaming", {
+  expect_snapshot(
+    spq_init() %>%
+      spq_add("?film wdt:P31 wd:Q11424") %>%
+      spq_label(film) %>%
+      spq_add("?film wdt:P577 ?date") %>%
+      spq_mutate(date = year(date)) %>%
+      spq_mutate(date = date - 2000)
+  )
+})
+

--- a/tests/testthat/test-spq_summarise.R
+++ b/tests/testthat/test-spq_summarise.R
@@ -45,3 +45,37 @@ test_that("spq_summarise() works", {
       spq_summarise(n_films = n())
   )
 })
+
+test_that("spq_summarize() works with renaming", {
+  expect_snapshot(
+    spq_init() %>%
+      spq_add("?item wdt:P361 wd:Q297853") %>%
+      spq_add("?item wdt:P1082 ?folkm_ngd") %>%
+      spq_add("?area wdt:P31 wd:Q1907114") %>%
+      spq_label(area) %>%
+      spq_add("?area wdt:P527 ?item") %>%
+      spq_group_by(area, area_label)  %>%
+      spq_summarise(folkm_ngd = sum(folkm_ngd))
+  )
+
+  expect_snapshot(
+    spq_init() %>%
+      spq_add("?film wdt:P31 wd:Q11424") %>%
+      spq_add("?film wdt:P840 ?loc") %>%
+      spq_add("?film wdt:P577 ?date") %>%
+      spq_mutate(year=year(date)) %>%
+      spq_mutate(yearmin = min(year)) %>%
+      spq_group_by(loc, yearmin) %>%
+      spq_summarize(n_films = n())
+  )
+
+  expect_snapshot(
+    spq_init() %>%
+      spq_add("?film wdt:P31 wd:Q11424") %>%
+      spq_head(10) %>%
+      spq_add("?film wdt:P577 ?date") %>%
+      spq_mutate(year = year(date)) %>%
+      spq_group_by(filmLabel,loc) %>%
+      spq_summarise(year = min(year))
+  )
+})

--- a/tests/testthat/test-spq_summarise.R
+++ b/tests/testthat/test-spq_summarise.R
@@ -64,8 +64,8 @@ test_that("spq_summarize() works with renaming", {
       spq_add("?film wdt:P840 ?loc") %>%
       spq_add("?film wdt:P577 ?date") %>%
       spq_mutate(year=year(date)) %>%
-      spq_mutate(yearmin = min(year)) %>%
-      spq_group_by(loc, yearmin) %>%
+      spq_mutate(year = min(year)) %>%
+      spq_group_by(loc, year) %>%
       spq_summarize(n_films = n())
   )
 


### PR DESCRIPTION
Fix #97
Fix #95

TODOS
- [x] I need to add docs of this behavior "somewhere".
- [x] @lvaudor please look at this and at the examples I put in the two linked issues + try out other examples you might have, but I want to have a look again before we merge, with fresh eyes (back from vacation).